### PR TITLE
Extension of the tool for csv files

### DIFF
--- a/datasets.txt
+++ b/datasets.txt
@@ -1,0 +1,3 @@
+accomodation https://tourism.api.opendatahub.bz.it/v1/Accommodation/5CEA544EE34639034F07B79D4AEEB603_REDUCED?idsource=lts&availabilitychecklanguage=en&roominfo=1-18%2C18&bokfilter=hgv&source=sinfo&detail=0&removenullvalues=false
+event https://tourism.api.opendatahub.bz.it/v1/Event/BFEB2DDB0FD54AC9BC040053A5514A92_REDUCED?removenullvalues=false
+weather https://tourism.api.opendatahub.bz.it/v1/Weather?language=en&extended=true

--- a/parse_tourism_API_fields.py
+++ b/parse_tourism_API_fields.py
@@ -46,8 +46,8 @@ def attribute_is_str(string, attribute, file, indent_level):
 
 def main():
     #accomodation dataset call
-    #request_url = "https://tourism.api.opendatahub.bz.it/v1/Accommodation/5CEA544EE34639034F07B79D4AEEB603_REDUCED?idsource=lts&availabilitychecklanguage=en&roominfo=1-18%2C18&bokfilter=hgv&source=sinfo&detail=0&removenullvalues=false"
-    #dataset = "accomodation"
+    request_url = "https://tourism.api.opendatahub.bz.it/v1/Accommodation/5CEA544EE34639034F07B79D4AEEB603_REDUCED?idsource=lts&availabilitychecklanguage=en&roominfo=1-18%2C18&bokfilter=hgv&source=sinfo&detail=0&removenullvalues=false"
+    dataset = "accomodation"
 
     #event dataset call
     #request_url = "https://tourism.api.opendatahub.bz.it/v1/Event/BFEB2DDB0FD54AC9BC040053A5514A92_REDUCED?removenullvalues=false"

--- a/parse_tourism_API_fields.py
+++ b/parse_tourism_API_fields.py
@@ -46,8 +46,8 @@ def attribute_is_str(string, attribute, file, indent_level):
 
 def main():
     #accomodation dataset call
-    request_url = "https://tourism.api.opendatahub.bz.it/v1/Accommodation/5CEA544EE34639034F07B79D4AEEB603_REDUCED?idsource=lts&availabilitychecklanguage=en&roominfo=1-18%2C18&bokfilter=hgv&source=sinfo&detail=0&removenullvalues=false"
-    dataset = "accomodation"
+    # request_url = "https://tourism.api.opendatahub.bz.it/v1/Accommodation/5CEA544EE34639034F07B79D4AEEB603_REDUCED?idsource=lts&availabilitychecklanguage=en&roominfo=1-18%2C18&bokfilter=hgv&source=sinfo&detail=0&removenullvalues=false"
+    # dataset = "accomodation"
 
     #event dataset call
     #request_url = "https://tourism.api.opendatahub.bz.it/v1/Event/BFEB2DDB0FD54AC9BC040053A5514A92_REDUCED?removenullvalues=false"

--- a/parse_tourism_API_fields_csv.py
+++ b/parse_tourism_API_fields_csv.py
@@ -1,0 +1,86 @@
+import requests
+import re
+import json
+
+
+def attribute_is_list(key, list, file):
+    if len(list)==0:
+        file.write("list name=\"" + key +  "\",--empty-- \n")
+    else:
+        file.write("list name=\"" + key +  "\",--start-- \n")
+
+        while len(list)!=0:
+
+            list_value = list.pop()
+
+            if(type(list_value) is dict and len(list_value) != 0):
+                attribute_is_dict(key, list_value, file)
+
+            if(type(list_value) is str):
+                attribute_is_str("attribute",list_value, file)
+                        
+            if(type(list_value) is list):
+                attribute_is_list(list_value, file)
+
+        file.write("list name=\"" + key +  "\",--end-- \n")
+
+
+def attribute_is_dict(key,attributes_dict, file):
+    if len(attributes_dict)==0:
+        file.write("dictionary name=\"" + key +  "\",--empty-- \n")
+    else:
+        file.write("dictionary name=\"" + key +  "\",--start-- \n")
+
+        for inner_key in attributes_dict:
+            if type(attributes_dict.get(inner_key)) is dict:
+
+                attribute_is_dict(inner_key,attributes_dict.get(inner_key), file)
+
+            else:
+                attribute_is_str("attribute",inner_key, file)
+
+        file.write("dictionary name=\"" + key +  "\",--end-- \n")
+
+
+def attribute_is_str(string, attribute, file):    
+
+        file.write(string +","+attribute + "," + "\n")
+
+
+def input_datasets_to_list(file_name):
+    input_datasets = open(file_name,'r')
+    return input_datasets.readlines()
+
+
+def main():
+
+    datasets = input_datasets_to_list('datasets.txt')
+    for line in datasets:
+        
+        dataset = line.split()[0]
+        request_url = line.split()[1]    
+
+
+        file = open("keys_list_tourism_" + dataset + ".csv", "w+")
+        file.write("type identifier," + "attribute name" + "\n\n")
+
+        json_request = requests.get(request_url)
+        json_data = json_request.json()
+
+
+        for key in json_data:
+            value = json_data.get(key)
+            
+            if type(value) is list:
+                attribute_is_list(key, value, file)
+
+            elif type(value) is dict:
+                attribute_is_dict(key, value, file)
+            
+            else:
+                attribute_is_str("attribute",key, file)
+
+        file.close()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The additional script for csv files works a bit differently than the original one. The names of the datasets and their URLs are no longer written directly in the source code, but in the "datasets.txt" file, where the syntax is as follows:
```
name_of_dataset1 URL_of_dataset1
name_of_dataset2 URL_of_dataset2
"
"
```
(Samples from the xml parser have been adopted)